### PR TITLE
Start on unique non-3000 port, to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ It's simple Ruby on Rails app, following standard Rails conventions, with a coup
   $ bundle exec rails s
   ```
 
-You'll be able to see the app running here: [localhost:3000](http://localhost:3000/)
+You'll be able to see the app running here: [localhost:3003](http://localhost:3003/)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,15 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+require 'rails/commands/server'
+
+# Run on a distinct port, to avoid clashing with other govuk-frontend apps
+# http://stackoverflow.com/questions/18103316/how-to-change-default-port-of-a-rails-4-app/19586744#19586744
+module DefaultOptions
+  def default_options
+    super.merge!(Port: 3003)
+  end
+end
+
+Rails::Server.send(:prepend, DefaultOptions)


### PR DESCRIPTION
1. Avoids problems where govuk_frontend_alpha/Fractal is running on
   3000 by default, and starting this app conflicts. We should be able
   to run both apps side by side, on different ports by default.

2. This allows the use of `pow` to map different apps/ports to development
   domains. I've been finding keeping track of which localhost/port combo
   a particular app is running on, pinning to a unique default port helps
   and allows mapping a custom domain through pow, eg I have:

   govuk-frontend.dev => localhost:3000
   rails-govuk-frontend.dev => localhost:3003

pow: http://pow.cx/manual.html